### PR TITLE
Fix timestamp endianness

### DIFF
--- a/src/main/java/com/vivokey/nfcsnoopdecoder/App.java
+++ b/src/main/java/com/vivokey/nfcsnoopdecoder/App.java
@@ -57,6 +57,7 @@ public class App {
         byte[] version = { byteArr[0] };
         // Wrap the long in a ByteBuffer to allow an easy read
         ByteBuffer longReader = ByteBuffer.wrap(byteArr, 1, 8);
+        longReader.order(ByteOrder.LITTLE_ENDIAN);
         long lastTimestamp = longReader.getLong();
         System.out.println("NFCSnoop version: " + Hex.encodeHexString(version));
         System.out.println("Last timestamp: " + lastTimestamp);


### PR DESCRIPTION
Hello 👋

Thank you for making this, I'm currently using your project to try and understand an NFC dump 😊

I noticed the Unix timestamp was a large negative number and figured it was probably an endianness issue. Sure enough, the value is little-endian, so I made that change.

Kind regards.
Iyassou